### PR TITLE
Issue Command

### DIFF
--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -28,73 +28,90 @@ from carberretta import Config
 from carberretta.utils import DEFAULT_EMBED_COLOUR, ROOT_DIR, chron, converters, menu
 
 
+async def issue_embed(issue: Issue.Issue, issue_number: int, author: discord.Member) -> dict:
+    issue_open = "Open"
+    issue_color = 0x17A007
+    issue_body = issue.body
+    issue_status = "Unknown"
+    issue_types = []
+    issue_type_label = "Type"
+    issue_milestone = "None"
+    issue_creator = issue.user.login
+
+    if issue.closed_at:
+        issue_open = "Closed"
+        issue_color = DEFAULT_EMBED_COLOUR
+
+    if len(issue.body) > 300:
+        issue_body = f"{issue.body[:300]}..."
+
+        if issue.body[299] == " ":
+            issue_body = f"{issue.body[:299]}..."
+
+    for label in issue.labels:
+        if label.name.startswith("status/"):
+            issue_status = label.name[7:].capitalize()
+            continue
+
+        if label.name.startswith("type/"):
+            issue_types.append(label.name[5:].capitalize())
+            continue
+
+    if issue.milestone:
+        issue_milestone = issue.milestone.title
+
+    if issue.user.name:
+        issue_creator = f"{issue.user.name} ({issue.user.login})"
+
+    if len(issue_types) > 1:
+        issue_type_label = "Types"
+
+    if not len(issue_types) > 0:
+        issue_types = ["Unknown"]
+
+    return {
+        "title": f"{issue_open}: {issue.title}",
+        "description": f"Click [here](https://github.com/Carberra/Carberretta/issues/{issue_number}) to view on the web version.",
+        "color": issue_color,
+        "author": {"name": "Query"},
+        "footer": {"text": f"Requested by {author.display_name}", "icon_url": f"{author.avatar_url}",},
+        "fields": [
+            {"name": "Description", "value": issue_body, "inline": False},
+            {"name": "Status", "value": issue_status, "inline": True},
+            {"name": issue_type_label, "value": ", ".join(issue_types), "inline": True},
+            {"name": "Milestone", "value": issue_milestone, "inline": True},
+            {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
+            {"name": "Created by", "value": issue_creator, "inline": True},
+            {
+                "name": "Existed for",
+                "value": chron.short_delta(datetime.utcnow() - issue.created_at),
+                "inline": True,
+            },
+        ],
+    }
+
+
+class SearchMenu(menu.NumberedSelectionMenu):
+    def __init__(self, ctx, data, results, pagemap):
+        self.data = data
+        super().__init__(ctx, results, pagemap)
+
+    async def start(self):
+        if (r := await super().start()) is not None:
+            await self.display_issue(r)
+
+    async def display_issue(self, name):
+        for issue in self.data:
+            if issue.title == name:
+                await self.message.clear_reactions()
+                await self.message.edit(embed=discord.Embed.from_dict(await issue_embed(issue, issue.number, self.ctx.author)))
+
+
 class Meta(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
         # self.bot.remove_command("help")
-
-    async def issue_embed(self, issue: Issue.Issue, issue_number: int, author: discord.Member) -> dict:
-        issue_open = "Open"
-        issue_color = 0x17A007
-        issue_body = issue.body
-        issue_status = "Unknown"
-        issue_types = []
-        issue_type_label = "Type"
-        issue_milestone = "None"
-        issue_creator = issue.user.login
-
-        if issue.closed_at:
-            issue_open = "Closed"
-            issue_color = DEFAULT_EMBED_COLOUR
-
-        if len(issue.body) > 300:
-            issue_body = f"{issue.body[:300]}..."
-
-            if issue.body[299] == " ":
-                issue_body = f"{issue.body[:299]}..."
-
-        for label in issue.labels:
-            if label.name.startswith("status/"):
-                issue_status = label.name[7:].capitalize()
-                continue
-
-            if label.name.startswith("type/"):
-                issue_types.append(label.name[5:].capitalize())
-                continue
-
-        if issue.milestone:
-            issue_milestone = issue.milestone.title
-
-        if issue.user.name:
-            issue_creator = f"{issue.user.name} ({issue.user.login})"
-
-        if len(issue_types) > 1:
-            issue_type_label = "Types"
-
-        if not len(issue_types) > 0:
-            issue_types = ["Unknown"]
-
-        return {
-            "title": f"{issue_open}: {issue.title}",
-            "description": f"Click [here](https://github.com/Carberra/Carberretta/issues/{issue_number}) to view on the web version.",
-            "color": issue_color,
-            "author": {"name": "Query"},
-            "footer": {"text": f"Requested by {author.display_name}", "icon_url": f"{author.avatar_url}",},
-            "fields": [
-                {"name": "Description", "value": issue_body, "inline": False},
-                {"name": "Status", "value": issue_status, "inline": True},
-                {"name": issue_type_label, "value": ", ".join(issue_types), "inline": True},
-                {"name": "Milestone", "value": issue_milestone, "inline": True},
-                {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
-                {"name": "Created by", "value": issue_creator, "inline": True},
-                {
-                    "name": "Existed for",
-                    "value": chron.short_delta(datetime.utcnow() - issue.created_at),
-                    "inline": True,
-                },
-            ],
-        }
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
@@ -237,10 +254,24 @@ class Meta(commands.Cog):
                 await ctx.send("Invalid issue number")
                 return
 
-            await ctx.send(embed=discord.Embed.from_dict(await self.issue_embed(issue, issue_number, ctx.author)))
+            await ctx.send(embed=discord.Embed.from_dict(await issue_embed(issue, issue_number, ctx.author)))
 
         except ValueError:
-            await ctx.send("Query Issues (coming soon)")
+            data = self.gh.search_issues(f"{issue_query} is:issue repo:Carberra/Carberretta")
+
+            pagemap = {
+                "title": "Search results",
+                "description": f"{data.totalCount} result(s).",
+                "color": DEFAULT_EMBED_COLOUR,
+                "author": {"name": "Query"},
+                "footer": {"text": f"Requested by {ctx.author.display_name}", "icon_url": f"{ctx.author.avatar_url}",},
+            }
+            results = [item.title for item in data]
+
+            if not results:
+                return await ctx.send("No results found.")
+
+            await SearchMenu(ctx, data, results, pagemap).start()
 
     @commands.command(name="shutdown")
     @commands.is_owner()

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -252,7 +252,7 @@ class Meta(commands.Cog):
             try:
                 issue = self.gh.get_repo("Carberra/Carberretta").get_issue(number=issue_number)
             except UnknownObjectException:
-                await ctx.send("Invalid issue number")
+                await ctx.send("Invalid issue number.")
                 return
 
             await ctx.send(embed=discord.Embed.from_dict(await issue_embed(issue, issue_number, ctx.author)))

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -25,7 +25,7 @@ from psutil import Process, virtual_memory
 from pygount import SourceAnalysis
 
 from carberretta import Config
-from carberretta.utils import DEFAULT_EMBED_COLOUR, ROOT_DIR, chron, converters
+from carberretta.utils import DEFAULT_EMBED_COLOUR, ROOT_DIR, chron, converters, menu
 
 
 class Meta(commands.Cog):
@@ -35,65 +35,66 @@ class Meta(commands.Cog):
         # self.bot.remove_command("help")
 
     async def issue_embed(self, issue: Issue.Issue, issue_number: int, author: discord.Member) -> dict:
-            issue_open = "Open"
-            issue_color = 0x17a007
-            issue_body = issue.body
-            issue_status = "Unknown"
-            issue_types = []
-            issue_type_label = "Type"
-            issue_milestone = "None"
-            issue_creator = issue.user.login
+        issue_open = "Open"
+        issue_color = 0x17A007
+        issue_body = issue.body
+        issue_status = "Unknown"
+        issue_types = []
+        issue_type_label = "Type"
+        issue_milestone = "None"
+        issue_creator = issue.user.login
 
-            if issue.closed_at:
-                issue_open = "Closed"
-                issue_color = DEFAULT_EMBED_COLOUR
+        if issue.closed_at:
+            issue_open = "Closed"
+            issue_color = DEFAULT_EMBED_COLOUR
 
-            if len(issue.body) > 300:
-                issue_body = f"{issue.body[:300]}..."
+        if len(issue.body) > 300:
+            issue_body = f"{issue.body[:300]}..."
 
-                if issue.body[299] == " ":
-                    issue_body = f"{issue.body[:299]}..."
+            if issue.body[299] == " ":
+                issue_body = f"{issue.body[:299]}..."
 
-            for label in issue.labels:
-                if label.name.startswith("status/"):
-                    issue_status = label.name[7:].capitalize()
-                    continue
+        for label in issue.labels:
+            if label.name.startswith("status/"):
+                issue_status = label.name[7:].capitalize()
+                continue
 
-                if label.name.startswith("type/"):
-                    issue_types.append(label.name[5:].capitalize())
-                    continue
+            if label.name.startswith("type/"):
+                issue_types.append(label.name[5:].capitalize())
+                continue
 
-            if issue.milestone:
-                issue_milestone = issue.milestone.title
+        if issue.milestone:
+            issue_milestone = issue.milestone.title
 
-            if issue.user.name:
-                issue_creator = f"{issue.user.name} ({issue.user.login})"
+        if issue.user.name:
+            issue_creator = f"{issue.user.name} ({issue.user.login})"
 
-            if len(issue_types) > 1:
-                issue_type_label = "Types"
+        if len(issue_types) > 1:
+            issue_type_label = "Types"
 
-            if not len(issue_types) > 0:
-                issue_types = ["Unknown"]
+        if not len(issue_types) > 0:
+            issue_types = ["Unknown"]
 
-            return {
-                "title": f"{issue_open}: {issue.title}",
-                "description": f"Click [here](https://github.com/Carberra/Carberretta/issues/{issue_number}) to view on the web version.",
-                "color": issue_color,
-                "author": {"name": "Query"},
-                "footer": {
-                    "text": f"Requested by {author.display_name}",
-                    "icon_url": f"{author.avatar_url}",
+        return {
+            "title": f"{issue_open}: {issue.title}",
+            "description": f"Click [here](https://github.com/Carberra/Carberretta/issues/{issue_number}) to view on the web version.",
+            "color": issue_color,
+            "author": {"name": "Query"},
+            "footer": {"text": f"Requested by {author.display_name}", "icon_url": f"{author.avatar_url}",},
+            "fields": [
+                {"name": "Description", "value": issue_body, "inline": False},
+                {"name": "Status", "value": issue_status, "inline": True},
+                {"name": issue_type_label, "value": ", ".join(issue_types), "inline": True},
+                {"name": "Milestone", "value": issue_milestone, "inline": True},
+                {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
+                {"name": "Created by", "value": issue_creator, "inline": True},
+                {
+                    "name": "Existed for",
+                    "value": chron.short_delta(datetime.utcnow() - issue.created_at),
+                    "inline": True,
                 },
-                "fields": [
-                    {"name": "Description", "value": issue_body, "inline": False},
-                    {"name": "Status", "value": issue_status, "inline": True},
-                    {"name": issue_type_label, "value": ", ".join(issue_types), "inline": True},
-                    {"name": "Milestone", "value": issue_milestone, "inline": True},
-                    {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
-                    {"name": "Created by", "value": issue_creator, "inline": True},
-                    {"name": "Existed for", "value": chron.short_delta(datetime.utcnow() - issue.created_at), "inline": True},
-                ],
-            }
+            ],
+        }
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
@@ -236,11 +237,7 @@ class Meta(commands.Cog):
                 await ctx.send("Invalid issue number")
                 return
 
-            await ctx.send(
-                embed=discord.Embed.from_dict(
-                    await self.issue_embed(issue, issue_number, ctx.author)
-                )
-            )
+            await ctx.send(embed=discord.Embed.from_dict(await self.issue_embed(issue, issue_number, ctx.author)))
 
         except ValueError:
             await ctx.send("Query Issues (coming soon)")

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -31,7 +31,7 @@ from carberretta.utils import DEFAULT_EMBED_COLOUR, ROOT_DIR, chron, converters,
 async def issue_embed(issue: Issue.Issue, issue_number: int, author: discord.Member) -> dict:
     issue_open = "Open"
     issue_color = 0x17A007
-    issue_body = issue.body
+    issue_body = "*No description provided.*"
     issue_status = "Unknown"
     issue_types = []
     issue_type_label = "Type"
@@ -41,6 +41,9 @@ async def issue_embed(issue: Issue.Issue, issue_number: int, author: discord.Mem
     if issue.closed_at:
         issue_open = "Closed"
         issue_color = DEFAULT_EMBED_COLOUR
+
+    if issue.body:
+        issue_body = issue.body
 
     if len(issue.body) > 300:
         issue_body = f"{issue.body[:300]}..."

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -269,7 +269,7 @@ class Meta(commands.Cog):
             ]
 
             if not results:
-                return await ctx.send("No results found.")
+                return await ctx.send("No results found. Are you sure that's an issue for Carberretta?")
 
             if not len(results) > 1:
                 return await ctx.send(embed=discord.Embed.from_dict(await issue_embed(data[0], data[0].number, ctx.author)))

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -20,6 +20,7 @@ from time import time
 
 import discord
 from discord.ext import commands
+from github import Github
 from psutil import Process, virtual_memory
 from pygount import SourceAnalysis
 
@@ -36,6 +37,7 @@ class Meta(commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self) -> None:
         if not self.bot.ready.booted:
+            self.gh = Github(Config.GITHUB_API_TOKEN)
             self.bot.ready.up(self)
 
     @commands.command(name="about")
@@ -161,6 +163,10 @@ class Meta(commands.Cog):
                 location = module.replace(".", "/") + ".py"
 
             await ctx.send(f"<{source_url}/blob/master/{location}#L{firstlineno}-L{firstlineno + len(lines) - 1}>")
+
+    @commands.command(name="issue")
+    async def command_issue(self, ctx: commands.Context, issue_number: int) -> None:
+        await ctx.send(self.gh.get_repo("Carberra/Carberretta").get_issue(number=issue_number))
 
     @commands.command(name="shutdown")
     @commands.is_owner()

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -175,33 +175,65 @@ class Meta(commands.Cog):
                 await ctx.send("Invalid issue number")
                 return
 
-            issue_status = "Open"
+            issue_open = "Open"
+            issue_color = 0x17a007
+            issue_body = issue.body
+            issue_status = "Unknown"
+            issue_types = []
+            issue_type_label = "Type"
+            issue_milestone = "None"
+            issue_creator = issue.user.login
 
             if issue.closed_at:
-                issue_status = "Closed"
+                issue_open = "Closed"
+                issue_color = DEFAULT_EMBED_COLOUR
+
+            if len(issue.body) > 300:
+                issue_body = f"{issue.body[:300]}..."
+
+                if issue.body[299] == " ":
+                    issue_body = f"{issue.body[:299]}..."
+
+            for label in issue.labels:
+                if label.name.startswith("status/"):
+                    issue_status = label.name[7:].capitalize()
+                    continue
+
+                if label.name.startswith("type/"):
+                    issue_types.append(label.name[5:].capitalize())
+                    continue
+
+            if issue.milestone:
+                issue_milestone = issue.milestone.title
+
+            if issue.user.name:
+                issue_creator = f"{issue.user.name} ({issue.user.login})"
+
+            if len(issue_types) > 1:
+                issue_type_label = "Types"
+
+            if not len(issue_types) > 0:
+                issue_types = ["Unknown"]
 
             await ctx.send(
                 embed=discord.Embed.from_dict(
                     {
-                        "title": issue.title,
+                        "title": f"{issue_open}: {issue.title}",
                         "description": f"Click [here](https://github.com/Carberra/Carberretta/issues/{issue_number}) to view on the web version.",
-                        "color": DEFAULT_EMBED_COLOUR,
+                        "color": issue_color,
                         "author": {"name": "Query"},
                         "footer": {
                             "text": f"Requested by {ctx.author.display_name}",
                             "icon_url": f"{ctx.author.avatar_url}",
                         },
                         "fields": [
-                            {
-                                "name": "Description",
-                                "value": issue.body,
-                                "inline": False
-                            },
-                            {
-                                "name": "Status",
-                                "value": issue_status,
-                                "inline": True,
-                            },
+                            {"name": "Description", "value": issue_body, "inline": False},
+                            {"name": "Status", "value": issue_status, "inline": True},
+                            {"name": issue_type_label, "value": ", ".join(issue_types), "inline": True},
+                            {"name": "Milestone", "value": issue_milestone, "inline": True},
+                            {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
+                            {"name": "Created by", "value": issue_creator, "inline": True},
+                            {"name": "Existed for", "value": chron.short_delta(datetime.utcnow() - issue.created_at), "inline": True},
                         ],
                     }
                 )

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -102,7 +102,7 @@ class SearchMenu(menu.NumberedSelectionMenu):
 
     async def display_issue(self, name):
         for issue in self.data:
-            if issue.title == name:
+            if f"{issue.title} (#{issue.number})" == name:
                 await self.message.clear_reactions()
                 await self.message.edit(embed=discord.Embed.from_dict(await issue_embed(issue, issue.number, self.ctx.author)))
 

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -82,11 +82,7 @@ async def issue_embed(issue: Issue.Issue, issue_number: int, author: discord.Mem
             {"name": "Milestone", "value": issue_milestone, "inline": True},
             {"name": "Created by", "value": issue_creator, "inline": True},
             {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
-            {
-                "name": "Existed for",
-                "value": chron.short_delta(datetime.utcnow() - issue.created_at),
-                "inline": True,
-            },
+            {"name": "Existed for", "value": chron.short_delta(datetime.utcnow() - issue.created_at), "inline": True,},
         ],
     }
 
@@ -104,7 +100,9 @@ class SearchMenu(menu.NumberedSelectionMenu):
         for issue in self.data:
             if f"{issue.title} (#{issue.number})" == name:
                 await self.message.clear_reactions()
-                await self.message.edit(embed=discord.Embed.from_dict(await issue_embed(issue, issue.number, self.ctx.author)))
+                await self.message.edit(
+                    embed=discord.Embed.from_dict(await issue_embed(issue, issue.number, self.ctx.author))
+                )
 
 
 class Meta(commands.Cog):
@@ -266,7 +264,9 @@ class Meta(commands.Cog):
                 "author": {"name": "Query"},
                 "footer": {"text": f"Requested by {ctx.author.display_name}", "icon_url": f"{ctx.author.avatar_url}",},
             }
-            results = [f"{issue.title} (#{issue.number})" for issue in data]
+            results = [f"{issue.title} (#{issue.number})" for issue in data if not issue.closed_at] + [
+                f"{issue.title} (#{issue.number})" for issue in data if issue.closed_at
+            ]
 
             if not results:
                 return await ctx.send("No results found.")

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -70,7 +70,7 @@ async def issue_embed(issue: Issue.Issue, issue_number: int, author: discord.Mem
         issue_types = ["Unknown"]
 
     return {
-        "title": f"{issue_open}: {issue.title}",
+        "title": f"{issue_open}: {issue.title} (#{issue.number})",
         "description": f"Click [here](https://github.com/Carberra/Carberretta/issues/{issue_number}) to view on the web version.",
         "color": issue_color,
         "author": {"name": "Query"},
@@ -80,8 +80,8 @@ async def issue_embed(issue: Issue.Issue, issue_number: int, author: discord.Mem
             {"name": "Status", "value": issue_status, "inline": True},
             {"name": issue_type_label, "value": ", ".join(issue_types), "inline": True},
             {"name": "Milestone", "value": issue_milestone, "inline": True},
-            {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
             {"name": "Created by", "value": issue_creator, "inline": True},
+            {"name": "Created at", "value": chron.long_date(issue.created_at), "inline": True},
             {
                 "name": "Existed for",
                 "value": chron.short_delta(datetime.utcnow() - issue.created_at),
@@ -266,7 +266,7 @@ class Meta(commands.Cog):
                 "author": {"name": "Query"},
                 "footer": {"text": f"Requested by {ctx.author.display_name}", "icon_url": f"{ctx.author.avatar_url}",},
             }
-            results = [item.title for item in data]
+            results = [f"{issue.title} (#{issue.number})" for issue in data]
 
             if not results:
                 return await ctx.send("No results found.")

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -20,7 +20,7 @@ from time import time
 
 import discord
 from discord.ext import commands
-from github import Github, UnknownObjectException, Issue
+from github import Github, Issue, UnknownObjectException
 from psutil import Process, virtual_memory
 from pygount import SourceAnalysis
 

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -275,7 +275,9 @@ class Meta(commands.Cog):
                 return await ctx.send("No results found. Are you sure that's an issue for Carberretta?")
 
             if not len(results) > 1:
-                return await ctx.send(embed=discord.Embed.from_dict(await issue_embed(data[0], data[0].number, ctx.author)))
+                return await ctx.send(
+                    embed=discord.Embed.from_dict(await issue_embed(data[0], data[0].number, ctx.author))
+                )
 
             await SearchMenu(ctx, data, results, pagemap).start()
 

--- a/carberretta/bot/cogs/meta.py
+++ b/carberretta/bot/cogs/meta.py
@@ -271,6 +271,9 @@ class Meta(commands.Cog):
             if not results:
                 return await ctx.send("No results found.")
 
+            if not len(results) > 1:
+                return await ctx.send(embed=discord.Embed.from_dict(await issue_embed(data[0], data[0].number, ctx.author)))
+
             await SearchMenu(ctx, data, results, pagemap).start()
 
     @commands.command(name="shutdown")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       PATRON_ROLE_ID: int:691858776147623996
       TWITCH_SUB_ROLE_ID: int:829026839941873689
       BOOSTER_ROLE_ID: int:657197640538259508
+      GITHUB_API_TOKEN: file:/run/secrets/github-api-token
 
     secrets:
       - token
@@ -43,6 +44,8 @@ secrets:
     file: ./secrets/token
   yt-api-key:
     file: ./secrets/yt-api-key
+  github-api-token:
+    file: ./secrets/github-api-token
 
 volumes:
   data:

--- a/poetry.lock
+++ b/poetry.lock
@@ -110,6 +110,17 @@ typed-ast = ">=1.4.0"
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
+name = "cffi"
+version = "1.14.5"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "chardet"
 version = "4.0.0"
 description = "Universal encoding detector for Python 2 and 3"
@@ -124,6 +135,20 @@ description = "Composable command line interface toolkit"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "deprecated"
+version = "1.2.12"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "discord.py"
@@ -208,6 +233,31 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
 
 [[package]]
+name = "pycparser"
+version = "2.20"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pygithub"
+version = "1.55"
+description = "Use the full Github API v3"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+deprecated = "*"
+pyjwt = ">=2.0"
+pynacl = ">=1.4.0"
+requests = ">=2.14.0"
+
+[package.extras]
+integrations = ["cryptography"]
+
+[[package]]
 name = "pygments"
 version = "2.8.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -225,6 +275,36 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 pygments = ">=2.0"
+
+[[package]]
+name = "pyjwt"
+version = "2.0.1"
+description = "JSON Web Token implementation in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+crypto = ["cryptography (>=3.3.1,<4.0.0)"]
+dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1,<4.0.0)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
+
+[[package]]
+name = "pynacl"
+version = "1.4.0"
+description = "Python binding to the Networking and Cryptography (NaCl) library"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+cffi = ">=1.4.1"
+six = "*"
+
+[package.extras]
+docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
+tests = ["pytest (>=3.2.1,!=3.3.0)", "hypothesis (>=3.27.0)"]
 
 [[package]]
 name = "python-dotenv"
@@ -252,6 +332,18 @@ description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "requests"
+version = "2.15.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+security = ["cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
 name = "six"
@@ -297,6 +389,14 @@ python-versions = "*"
 pytz = "*"
 
 [[package]]
+name = "wrapt"
+version = "1.12.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "yarl"
 version = "1.6.3"
 description = "Yet another URL library"
@@ -311,7 +411,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "e6968435c6bb1d45299c16549189c8e3658a73097f367c72fd2cd2b94b48de84"
+content-hash = "43b9fe0a40676cbce4e76100ec24fac5de857c185291a39de8acce4eafe6c8d7"
 
 [metadata.files]
 aiofiles = [
@@ -381,6 +481,45 @@ black = [
     {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
     {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
+cffi = [
+    {file = "cffi-1.14.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991"},
+    {file = "cffi-1.14.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1"},
+    {file = "cffi-1.14.5-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:99cd03ae7988a93dd00bcd9d0b75e1f6c426063d6f03d2f90b89e29b25b82dfa"},
+    {file = "cffi-1.14.5-cp27-cp27m-win32.whl", hash = "sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3"},
+    {file = "cffi-1.14.5-cp27-cp27m-win_amd64.whl", hash = "sha256:51182f8927c5af975fece87b1b369f722c570fe169f9880764b1ee3bca8347b5"},
+    {file = "cffi-1.14.5-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482"},
+    {file = "cffi-1.14.5-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6"},
+    {file = "cffi-1.14.5-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045"},
+    {file = "cffi-1.14.5-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a465da611f6fa124963b91bf432d960a555563efe4ed1cc403ba5077b15370aa"},
+    {file = "cffi-1.14.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406"},
+    {file = "cffi-1.14.5-cp35-cp35m-win32.whl", hash = "sha256:72d8d3ef52c208ee1c7b2e341f7d71c6fd3157138abf1a95166e6165dd5d4369"},
+    {file = "cffi-1.14.5-cp35-cp35m-win_amd64.whl", hash = "sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315"},
+    {file = "cffi-1.14.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5"},
+    {file = "cffi-1.14.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132"},
+    {file = "cffi-1.14.5-cp36-cp36m-win32.whl", hash = "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53"},
+    {file = "cffi-1.14.5-cp36-cp36m-win_amd64.whl", hash = "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813"},
+    {file = "cffi-1.14.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1"},
+    {file = "cffi-1.14.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49"},
+    {file = "cffi-1.14.5-cp37-cp37m-win32.whl", hash = "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62"},
+    {file = "cffi-1.14.5-cp37-cp37m-win_amd64.whl", hash = "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4"},
+    {file = "cffi-1.14.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e"},
+    {file = "cffi-1.14.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827"},
+    {file = "cffi-1.14.5-cp38-cp38-win32.whl", hash = "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e"},
+    {file = "cffi-1.14.5-cp38-cp38-win_amd64.whl", hash = "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396"},
+    {file = "cffi-1.14.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c"},
+    {file = "cffi-1.14.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee"},
+    {file = "cffi-1.14.5-cp39-cp39-win32.whl", hash = "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396"},
+    {file = "cffi-1.14.5-cp39-cp39-win_amd64.whl", hash = "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d"},
+    {file = "cffi-1.14.5.tar.gz", hash = "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"},
+]
 chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
@@ -388,6 +527,10 @@ chardet = [
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+deprecated = [
+    {file = "Deprecated-1.2.12-py2.py3-none-any.whl", hash = "sha256:08452d69b6b5bc66e8330adde0a4f8642e969b9e1702904d137eeb29c8ffc771"},
+    {file = "Deprecated-1.2.12.tar.gz", hash = "sha256:6d2de2de7931a968874481ef30208fd4e08da39177d61d3d4ebdf4366e7dbca1"},
 ]
 "discord.py" = [
     {file = "discord.py-1.7.1-py3-none-any.whl", hash = "sha256:399b80d576a63fa901300e80080568e1d9cd9c21260ca622fd7145c0009278fa"},
@@ -494,12 +637,44 @@ psutil = [
     {file = "psutil-5.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3"},
     {file = "psutil-5.8.0.tar.gz", hash = "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6"},
 ]
+pycparser = [
+    {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
+    {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+]
+pygithub = [
+    {file = "PyGithub-1.55-py3-none-any.whl", hash = "sha256:2caf0054ea079b71e539741ae56c5a95e073b81fa472ce222e81667381b9601b"},
+    {file = "PyGithub-1.55.tar.gz", hash = "sha256:1bbfff9372047ff3f21d5cd8e07720f3dbfdaf6462fcaed9d815f528f1ba7283"},
+]
 pygments = [
     {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
     {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
 ]
 pygount = [
     {file = "pygount-1.2.4-py3-none-any.whl", hash = "sha256:8ec56e58cfcb2be8bb54f32f02e7130d33302e2543c8a37b441e606ea3b8a2c5"},
+]
+pyjwt = [
+    {file = "PyJWT-2.0.1-py3-none-any.whl", hash = "sha256:b70b15f89dc69b993d8a8d32c299032d5355c82f9b5b7e851d1a6d706dffe847"},
+    {file = "PyJWT-2.0.1.tar.gz", hash = "sha256:a5c70a06e1f33d81ef25eecd50d50bd30e34de1ca8b2b9fa3fe0daaabcf69bf7"},
+]
+pynacl = [
+    {file = "PyNaCl-1.4.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff"},
+    {file = "PyNaCl-1.4.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514"},
+    {file = "PyNaCl-1.4.0-cp27-cp27m-win32.whl", hash = "sha256:2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574"},
+    {file = "PyNaCl-1.4.0-cp27-cp27m-win_amd64.whl", hash = "sha256:f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80"},
+    {file = "PyNaCl-1.4.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-win32.whl", hash = "sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634"},
+    {file = "PyNaCl-1.4.0-cp35-abi3-win_amd64.whl", hash = "sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6"},
+    {file = "PyNaCl-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4"},
+    {file = "PyNaCl-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25"},
+    {file = "PyNaCl-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4"},
+    {file = "PyNaCl-1.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6"},
+    {file = "PyNaCl-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f"},
+    {file = "PyNaCl-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f"},
+    {file = "PyNaCl-1.4.0-cp38-cp38-win32.whl", hash = "sha256:9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96"},
+    {file = "PyNaCl-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420"},
+    {file = "PyNaCl-1.4.0.tar.gz", hash = "sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.13.0.tar.gz", hash = "sha256:3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74"},
@@ -552,6 +727,10 @@ regex = [
     {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
     {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
 ]
+requests = [
+    {file = "requests-2.15.1-py2.py3-none-any.whl", hash = "sha256:ff753b2196cd18b1bbeddc9dcd5c864056599f7a7d9a4fb5677e723efa2b7fb9"},
+    {file = "requests-2.15.1.tar.gz", hash = "sha256:e5659b9315a0610505e050bb7190bf6fa2ccee1ac295f2b760ef9d8a03ebbb2e"},
+]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
@@ -600,6 +779,9 @@ typing-extensions = [
 tzlocal = [
     {file = "tzlocal-2.1-py2.py3-none-any.whl", hash = "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"},
     {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
+]
+wrapt = [
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 yarl = [
     {file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -389,6 +389,19 @@ python-versions = "*"
 pytz = "*"
 
 [[package]]
+name = "urllib3"
+version = "1.26.4"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotlipy (>=0.6.0)"]
+
+[[package]]
 name = "wrapt"
 version = "1.12.1"
 description = "Module for decorators, wrappers and monkey patching."
@@ -411,7 +424,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "43b9fe0a40676cbce4e76100ec24fac5de857c185291a39de8acce4eafe6c8d7"
+content-hash = "8bec352a60248173bde8abf8ff554b5414aed6c44cad660f572d11b431d8ad29"
 
 [metadata.files]
 aiofiles = [
@@ -779,6 +792,10 @@ typing-extensions = [
 tzlocal = [
     {file = "tzlocal-2.1-py2.py3-none-any.whl", hash = "sha256:e2cb6c6b5b604af38597403e9852872d7f534962ae2954c7f35efcb1ccacf4a4"},
     {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
+    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pygount = "^1.2.4"
 python-dotenv = "^0.13.0"
 toml = "^0.10.1"
 PyGithub = "^1.55"
+urllib3 = "^1.26.4"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.782"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ apscheduler = "^3.6.3"
 "discord.py" = "^1.5.0"
 kaomoji = "^0.1.0"
 psutil = "^5.8.0"
+PyGithub = "^1.55"
 pygount = "^1.2.4"
 python-dotenv = "^0.13.0"
 toml = "^0.10.1"
-PyGithub = "^1.55"
 urllib3 = "^1.26.4"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ psutil = "^5.8.0"
 pygount = "^1.2.4"
 python-dotenv = "^0.13.0"
 toml = "^0.10.1"
+PyGithub = "^1.55"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.782"


### PR DESCRIPTION
## Description

This adds the issue command. It is similar to the PEP command (#67) as well as the YouTube search command. If you do `+issue 1` or `+issue #1`, it gets the issue with the number 1 from this repo. It checks if the number is a valid issue number. If the query provided is not an number (or number preceded by a `#`), it searches the issues with the provided query. It uses the same menu to display and allow selection of these results that the YouTube search command does. When you select an issue, it displays the info for that issue. When using a text search query, if there is only one issue in the search results, it skips the menu and jumps straight to that issue as if you had specified a issue number.

Also, this command uses the GitHub API via a module called [PyGithub](https://pypi.org/project/PyGithub/). You will need to have an API token (personal access) for this to work. The token does not need any scopes as all it is doing is reading the data, not modifying/creating anything. Me and @parafoxia have alreadly discussed this some. If you need any help with getting the token and all configured/put into the bot, please DM me on discord. Thanks!

## Closes

 - Closes #70 