### PR TITLE
optimize database calls in feeds cog

### DIFF
--- a/carberretta/bot/cogs/feeds.py
+++ b/carberretta/bot/cogs/feeds.py
@@ -299,7 +299,7 @@ class Feeds(commands.Cog):
                 # The stream is not live and last we checked it was (stream is over)
 
                 await self.bot.db.execute(
-                    "UPDATE streams SET StreamLive = ?, StreamEnd = ? WHERE ID = 1", (0), (dt.datetime.utcnow())
+                    "UPDATE streams SET StreamLive = ?, StreamEnd = ? WHERE ID = 1", 0, dt.datetime.utcnow()
                 )
 
                 start, stream_message, end = await self.bot.db.record(

--- a/carberretta/data/static/build.sql
+++ b/carberretta/data/static/build.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS videos (
     ContentType text NOT NULL PRIMARY KEY,
-    ContentValue text default ""
+    ContentValue text DEFAULT ""
 );
 
 INSERT OR IGNORE INTO videos (ContentType)

--- a/carberretta/data/static/build.sql
+++ b/carberretta/data/static/build.sql
@@ -1,19 +1,24 @@
-CREATE TABLE IF NOT EXISTS feeds (
+CREATE TABLE IF NOT EXISTS videos (
     ContentType text NOT NULL PRIMARY KEY,
-    ContentValue text DEFAULT ""
+    ContentValue text default ""
 );
 
-INSERT OR IGNORE INTO feeds (ContentType, ContentValue)
-VALUES
-    ("video", ""),
-    ("vod", ""),
-    ("stream_start", ""),
-    ("stream_end", ""),
-    ("stream_live", "0"),
-    ("stream_message", "");
+INSERT OR IGNORE INTO videos (ContentType)
+VALUES ("video"), ("vod");
 
 CREATE TABLE IF NOT EXISTS premieres (
     VideoID text NOT NULL PRIMARY KEY,
-    Upcoming int,
-    Announced int
+    Upcoming integer,
+    Announced integer
 );
+
+CREATE TABLE IF NOT EXISTS streams (
+    ID integer NOT NULL PRIMARY KEY,
+    StreamStart numeric DEFAULT 0,
+    StreamEnd numeric DEFAULT 0,
+    StreamLive integer DEFAULT 0,
+    StreamMessage integer DEFAULT 0
+);
+
+INSERT OR IGNORE INTO streams (ID)
+VALUES (1);


### PR DESCRIPTION
- remove unnecessary db calls from for loop in `get_new_premieres()`.
- remove unnecessary calls to commit the db - 1min auto commit already scheduled.
- combine sql statements where possible.

Closes #94

This should significantly reduce the number of database calls.