### PR TITLE
Fix PEP Command Error

### DIFF
--- a/carberretta/bot/bot.py
+++ b/carberretta/bot/bot.py
@@ -22,7 +22,7 @@ class Bot(commands.Bot):
         self._static = "./carberretta/data/static"
 
         self.scheduler = AsyncIOScheduler()
-        self.session = ClientSession()
+        self.session = ClientSession(trust_env=True)
         self.db = Database(self)
         self.emoji = utils.EmojiGetter(self)
         self.loc = utils.CodeCounter()


### PR DESCRIPTION
This should fix the ClientConnectionError that was occuring with the PEP command occasionally. I am not really able to test this that much because I can't replicate the error that was occuring but I read that this should fix the problem. We will just have to see after it is deployed if this fixes it. If not, we can try some other things and see if any of them work.

## Closes

- Closes #75 