### PR TITLE
Add future annotations

### DIFF
--- a/carberretta/bot.py
+++ b/carberretta/bot.py
@@ -32,12 +32,11 @@ import traceback
 from pathlib import Path
 
 import hikari
+import lightbulb
 from aiohttp import ClientSession
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from hikari.events.base_events import FailedEventT
-from lightbulb import errors, events
-from lightbulb.app import BotApp
 from pytz import utc
 
 import carberretta
@@ -46,7 +45,7 @@ from carberretta.utils import helpers
 
 log = logging.getLogger(__name__)
 
-bot = BotApp(
+bot = lightbulb.BotApp(
     Config.TOKEN,
     default_enabled_guilds=Config.GUILD_ID,
     owner_ids=Config.OWNER_IDS,
@@ -109,11 +108,11 @@ async def on_error(event: hikari.ExceptionEvent[FailedEventT]) -> None:
     raise event.exception
 
 
-@bot.listen(events.CommandErrorEvent)
-async def on_command_error(event: events.CommandErrorEvent) -> None:
+@bot.listen(lightbulb.CommandErrorEvent)
+async def on_command_error(event: lightbulb.CommandErrorEvent) -> None:
     exc = getattr(event.exception, "__cause__", event.exception)
 
-    if isinstance(exc, errors.NotOwner):
+    if isinstance(exc, lightbulb.NotOwner):
         await event.context.respond("You need to be an owner to do that.")
         return
 

--- a/carberretta/db.py
+++ b/carberretta/db.py
@@ -26,6 +26,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import datetime as dt
 import logging
 import os
@@ -40,7 +42,7 @@ STRFTIME_PATTERN: t.Final = re.compile(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}")
 
 log = logging.getLogger(__name__)
 
-ValueT = t.Union[int, float, dt.datetime, str, None]
+ValueT = int | float | dt.datetime | str | None
 
 
 class RowData(dict[str, t.Any]):
@@ -63,7 +65,7 @@ class RowData(dict[str, t.Any]):
         raise ValueError("row data cannot be modified")
 
     @classmethod
-    def from_selection(cls, cur: aiosqlite.Cursor, row: aiosqlite.Row) -> "RowData":
+    def from_selection(cls, cur: aiosqlite.Cursor, row: aiosqlite.Row) -> RowData:
         def _resolve(field: int | float | str) -> t.Any:
             if isinstance(field, (int, float)) or not STRFTIME_PATTERN.match(field):
                 return field

--- a/carberretta/extensions/admin.py
+++ b/carberretta/extensions/admin.py
@@ -43,7 +43,7 @@ plugin = lightbulb.Plugin("Admin")
 @lightbulb.add_checks(lightbulb.owner_only)
 @lightbulb.command("shutdown", "Shut Carberretta down.", ephemeral=True)
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_shutdown(ctx: lightbulb.Context) -> None:
+async def cmd_shutdown(ctx: lightbulb.SlashContext) -> None:
     log.info("Shutdown signal received")
     await ctx.respond("Now shutting down.")
     await ctx.bot.close()
@@ -54,7 +54,7 @@ async def cmd_shutdown(ctx: lightbulb.Context) -> None:
 @lightbulb.option("id", "The error reference ID.")
 @lightbulb.command("error", "View an error.")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_error(ctx: lightbulb.Context) -> None:
+async def cmd_error(ctx: lightbulb.SlashContext) -> None:
     if len(search_id := ctx.options.id) < 5:
         await ctx.respond("Your search should be at least 5 characters long.")
         return

--- a/carberretta/extensions/admin.py
+++ b/carberretta/extensions/admin.py
@@ -26,37 +26,35 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import logging
-import typing as t
 from io import BytesIO
 
 import hikari
-from lightbulb import checks, commands, context, decorators, plugins
-
-if t.TYPE_CHECKING:
-    from lightbulb.app import BotApp
+import lightbulb
 
 log = logging.getLogger(__name__)
 
-plugin = plugins.Plugin("Admin")
+plugin = lightbulb.Plugin("Admin")
 
 
 @plugin.command
-@decorators.add_checks(checks.owner_only)
-@decorators.command("shutdown", "Shut Carberretta down.", ephemeral=True)
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_shutdown(ctx: context.base.Context) -> None:
+@lightbulb.add_checks(lightbulb.owner_only)
+@lightbulb.command("shutdown", "Shut Carberretta down.", ephemeral=True)
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_shutdown(ctx: lightbulb.Context) -> None:
     log.info("Shutdown signal received")
     await ctx.respond("Now shutting down.")
     await ctx.bot.close()
 
 
 @plugin.command
-@decorators.add_checks(checks.owner_only)
-@decorators.option("id", "The error reference ID.")
-@decorators.command("error", "View an error.")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_error(ctx: context.base.Context) -> None:
+@lightbulb.add_checks(lightbulb.owner_only)
+@lightbulb.option("id", "The error reference ID.")
+@lightbulb.command("error", "View an error.")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_error(ctx: lightbulb.Context) -> None:
     if len(search_id := ctx.options.id) < 5:
         await ctx.respond("Your search should be at least 5 characters long.")
         return
@@ -78,14 +76,12 @@ async def cmd_error(ctx: context.base.Context) -> None:
         f"Command: /{row.err_cmd}\nAt: {row.err_time}\n\n{row.err_text}".encode()
     )
     b.seek(0)
-    await message.edit(
-        content=None, attachment=hikari.files.Bytes(b, f"err{row.err_id}.txt")
-    )
+    await message.edit(content=None, attachment=hikari.Bytes(b, f"err{row.err_id}.txt"))
 
 
-def load(bot: "BotApp") -> None:
+def load(bot: lightbulb.BotApp) -> None:
     bot.add_plugin(plugin)
 
 
-def unload(bot: "BotApp") -> None:
+def unload(bot: lightbulb.BotApp) -> None:
     bot.remove_plugin(plugin)

--- a/carberretta/extensions/external.py
+++ b/carberretta/extensions/external.py
@@ -26,14 +26,13 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import typing as t
 
-from lightbulb import commands, context, decorators, plugins
+import lightbulb
 
-if t.TYPE_CHECKING:
-    from lightbulb.app import BotApp
-
-plugin = plugins.Plugin("External")
+plugin = lightbulb.Plugin("External")
 
 LINKS: t.Final = (
     "Docs",
@@ -50,18 +49,18 @@ LINKS: t.Final = (
 
 
 @plugin.command
-@decorators.option("target", "The link to show.", choices=LINKS)
-@decorators.command("link", "Retrieve a Carberra link.")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_link(ctx: context.base.Context) -> None:
+@lightbulb.option("target", "The link to show.", choices=LINKS)
+@lightbulb.command("link", "Retrieve a Carberra link.")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_link(ctx: lightbulb.Context) -> None:
     await ctx.respond(f"<https://{ctx.options.target.lower()}.carberra.xyz>")
 
 
 @plugin.command
-@decorators.option("number", "The PEP number to search for.")
-@decorators.command("pep", "Retrieve info on a Python Extension Protocol.")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_pep(ctx: context.base.Context) -> None:
+@lightbulb.option("number", "The PEP number to search for.")
+@lightbulb.command("pep", "Retrieve info on a Python Extension Protocol.")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_pep(ctx: lightbulb.Context) -> None:
     n = ctx.options.number
     url = f"https://python.org/dev/peps/pep-{n:>04}"
 
@@ -74,10 +73,10 @@ async def cmd_pep(ctx: context.base.Context) -> None:
 
 
 @plugin.command
-@decorators.option("query", "The thing to search.")
-@decorators.command("google", "Let me Google that for you...")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_google(ctx: context.base.Context) -> None:
+@lightbulb.option("query", "The thing to search.")
+@lightbulb.command("google", "Let me Google that for you...")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_google(ctx: lightbulb.Context) -> None:
     q = ctx.options.query
 
     if len(q) > 500:
@@ -88,10 +87,10 @@ async def cmd_google(ctx: context.base.Context) -> None:
 
 
 @plugin.command
-@decorators.option("query", "The thing to search.")
-@decorators.command("duckduckgo", "Let me Duck Duck Go that for you...")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_duckduckgo(ctx: context.base.Context) -> None:
+@lightbulb.option("query", "The thing to search.")
+@lightbulb.command("duckduckgo", "Let me Duck Duck Go that for you...")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_duckduckgo(ctx: lightbulb.Context) -> None:
     q = ctx.options.query
 
     if len(q) > 500:
@@ -101,9 +100,9 @@ async def cmd_duckduckgo(ctx: context.base.Context) -> None:
     await ctx.respond(f"<https://lmddgtfy.net/?q={q.replace(' ', '+')}>")
 
 
-def load(bot: "BotApp") -> None:
+def load(bot: lightbulb.BotApp) -> None:
     bot.add_plugin(plugin)
 
 
-def unload(bot: "BotApp") -> None:
+def unload(bot: lightbulb.BotApp) -> None:
     bot.remove_plugin(plugin)

--- a/carberretta/extensions/external.py
+++ b/carberretta/extensions/external.py
@@ -52,7 +52,7 @@ LINKS: t.Final = (
 @lightbulb.option("target", "The link to show.", choices=LINKS)
 @lightbulb.command("link", "Retrieve a Carberra link.")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_link(ctx: lightbulb.Context) -> None:
+async def cmd_link(ctx: lightbulb.SlashContext) -> None:
     await ctx.respond(f"<https://{ctx.options.target.lower()}.carberra.xyz>")
 
 
@@ -60,7 +60,7 @@ async def cmd_link(ctx: lightbulb.Context) -> None:
 @lightbulb.option("number", "The PEP number to search for.")
 @lightbulb.command("pep", "Retrieve info on a Python Extension Protocol.")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_pep(ctx: lightbulb.Context) -> None:
+async def cmd_pep(ctx: lightbulb.SlashContext) -> None:
     n = ctx.options.number
     url = f"https://python.org/dev/peps/pep-{n:>04}"
 
@@ -76,7 +76,7 @@ async def cmd_pep(ctx: lightbulb.Context) -> None:
 @lightbulb.option("query", "The thing to search.")
 @lightbulb.command("google", "Let me Google that for you...")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_google(ctx: lightbulb.Context) -> None:
+async def cmd_google(ctx: lightbulb.SlashContext) -> None:
     q = ctx.options.query
 
     if len(q) > 500:
@@ -90,7 +90,7 @@ async def cmd_google(ctx: lightbulb.Context) -> None:
 @lightbulb.option("query", "The thing to search.")
 @lightbulb.command("duckduckgo", "Let me Duck Duck Go that for you...")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_duckduckgo(ctx: lightbulb.Context) -> None:
+async def cmd_duckduckgo(ctx: lightbulb.SlashContext) -> None:
     q = ctx.options.query
 
     if len(q) > 500:

--- a/carberretta/extensions/gateway.py
+++ b/carberretta/extensions/gateway.py
@@ -26,21 +26,19 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import datetime as dt
 import logging
-import typing as t
 
 import hikari
-from lightbulb import plugins
-
-if t.TYPE_CHECKING:
-    from lightbulb.app import BotApp
+import lightbulb
 
 from carberretta import Config
 
 TIMEOUT = 600
 
-plugin = plugins.Plugin("Gateway")
+plugin = lightbulb.Plugin("Gateway")
 
 log = logging.getLogger(__name__)
 
@@ -163,9 +161,9 @@ async def on_member_update(event: hikari.MemberUpdateEvent) -> None:
         )
 
 
-def load(bot: "BotApp") -> None:
+def load(bot: lightbulb.BotApp) -> None:
     bot.add_plugin(plugin)
 
 
-def unload(bot: "BotApp") -> None:
+def unload(bot: lightbulb.BotApp) -> None:
     bot.remove_plugin(plugin)

--- a/carberretta/extensions/meta.py
+++ b/carberretta/extensions/meta.py
@@ -26,14 +26,15 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import datetime as dt
 import platform
 import time
-import typing as t
 from dataclasses import dataclass
 
 import hikari
-from lightbulb import commands, context, decorators, plugins
+import lightbulb
 from psutil import Process, virtual_memory
 from pygount import SourceAnalysis
 
@@ -41,10 +42,7 @@ import carberretta
 from carberretta import Config
 from carberretta.utils import chron, helpers
 
-if t.TYPE_CHECKING:
-    from lightbulb.app import BotApp
-
-plugin = plugins.Plugin("Meta")
+plugin = lightbulb.Plugin("Meta")
 
 
 @dataclass
@@ -53,7 +51,7 @@ class CodeCounter:
     docs: int = 0
     empty: int = 0
 
-    def count(self) -> "CodeCounter":
+    def count(self) -> CodeCounter:
         for file in carberretta.ROOT_DIR.rglob("*.py"):
             analysis = SourceAnalysis.from_file(file, "pygount", encoding="utf-8")
             self.code += analysis.code_count
@@ -64,18 +62,18 @@ class CodeCounter:
 
 
 @plugin.command
-@decorators.command("ping", "Get the average DWSP latency for the bot.")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_ping(ctx: context.base.Context) -> None:
+@lightbulb.command("ping", "Get the average DWSP latency for the bot.")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_ping(ctx: lightbulb.Context) -> None:
     await ctx.respond(
         f"Pong! DWSP latency: {ctx.bot.heartbeat_latency * 1_000:,.0f} ms."
     )
 
 
 @plugin.command
-@decorators.command("about", "View information about Carberretta.")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_about(ctx: context.base.Context) -> None:
+@lightbulb.command("about", "View information about Carberretta.")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_about(ctx: lightbulb.Context) -> None:
     if not (guild := ctx.get_guild()):
         return
 
@@ -109,9 +107,9 @@ async def cmd_about(ctx: context.base.Context) -> None:
 
 
 @plugin.command
-@decorators.command("stats", "View runtime stats for Carberretta.")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_stats(ctx: context.base.Context) -> None:
+@lightbulb.command("stats", "View runtime stats for Carberretta.")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_stats(ctx: lightbulb.Context) -> None:
     if not (guild := ctx.get_guild()):
         return
 
@@ -162,11 +160,11 @@ async def cmd_stats(ctx: context.base.Context) -> None:
     )
 
 
-def load(bot: "BotApp") -> None:
+def load(bot: lightbulb.BotApp) -> None:
     if not bot.d.loc:
         bot.d.loc = CodeCounter().count()
     bot.add_plugin(plugin)
 
 
-def unload(bot: "BotApp") -> None:
+def unload(bot: lightbulb.BotApp) -> None:
     bot.remove_plugin(plugin)

--- a/carberretta/extensions/meta.py
+++ b/carberretta/extensions/meta.py
@@ -64,7 +64,7 @@ class CodeCounter:
 @plugin.command
 @lightbulb.command("ping", "Get the average DWSP latency for the bot.")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_ping(ctx: lightbulb.Context) -> None:
+async def cmd_ping(ctx: lightbulb.SlashContext) -> None:
     await ctx.respond(
         f"Pong! DWSP latency: {ctx.bot.heartbeat_latency * 1_000:,.0f} ms."
     )
@@ -73,7 +73,7 @@ async def cmd_ping(ctx: lightbulb.Context) -> None:
 @plugin.command
 @lightbulb.command("about", "View information about Carberretta.")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_about(ctx: lightbulb.Context) -> None:
+async def cmd_about(ctx: lightbulb.SlashContext) -> None:
     if not (guild := ctx.get_guild()):
         return
 
@@ -109,7 +109,7 @@ async def cmd_about(ctx: lightbulb.Context) -> None:
 @plugin.command
 @lightbulb.command("stats", "View runtime stats for Carberretta.")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_stats(ctx: lightbulb.Context) -> None:
+async def cmd_stats(ctx: lightbulb.SlashContext) -> None:
     if not (guild := ctx.get_guild()):
         return
 

--- a/carberretta/extensions/text.py
+++ b/carberretta/extensions/text.py
@@ -26,26 +26,24 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import datetime as dt
-import typing as t
 import unicodedata
 
 import hikari
-from lightbulb import commands, context, decorators, plugins
+import lightbulb
 
 from carberretta.utils import helpers
 
-if t.TYPE_CHECKING:
-    from lightbulb.app import BotApp
-
-plugin = plugins.Plugin("Text")
+plugin = lightbulb.Plugin("Text")
 
 
 @plugin.command
-@decorators.option("characters", "The characters to get the information on.")
-@decorators.command("charinfo", "Get character information.")
-@decorators.implements(commands.slash.SlashCommand)
-async def cmd_charinfo(ctx: context.base.Context) -> None:
+@lightbulb.option("characters", "The characters to get the information on.")
+@lightbulb.command("charinfo", "Get character information.")
+@lightbulb.implements(lightbulb.SlashCommand)
+async def cmd_charinfo(ctx: lightbulb.Context) -> None:
     characters = ctx.options.characters
     if len(characters) > 15:
         await ctx.respond("You can only pass 15 characters at a time.")
@@ -77,9 +75,9 @@ async def cmd_charinfo(ctx: context.base.Context) -> None:
     )
 
 
-def load(bot: "BotApp") -> None:
+def load(bot: lightbulb.BotApp) -> None:
     bot.add_plugin(plugin)
 
 
-def unload(bot: "BotApp") -> None:
+def unload(bot: lightbulb.BotApp) -> None:
     bot.remove_plugin(plugin)

--- a/carberretta/extensions/text.py
+++ b/carberretta/extensions/text.py
@@ -43,7 +43,7 @@ plugin = lightbulb.Plugin("Text")
 @lightbulb.option("characters", "The characters to get the information on.")
 @lightbulb.command("charinfo", "Get character information.")
 @lightbulb.implements(lightbulb.SlashCommand)
-async def cmd_charinfo(ctx: lightbulb.Context) -> None:
+async def cmd_charinfo(ctx: lightbulb.SlashContext) -> None:
     characters = ctx.options.characters
     if len(characters) > 15:
         await ctx.respond("You can only pass 15 characters at a time.")

--- a/carberretta/utils/string.py
+++ b/carberretta/utils/string.py
@@ -50,6 +50,6 @@ def ordinal(number: int) -> str:
     return f"{number:,}th"
 
 
-def possessive(user: "Member" | "User") -> str:
+def possessive(user: Member | User) -> str:
     name = getattr(user, "display_name", user.username)
     return f"{name}'{'s' if not name.endswith('s') else ''}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiosqlite~=0.17
 apscheduler<4,>=3.8
 feedparser<7,>=6.0
 hikari[speedups]==2.0.0.dev104
-hikari-lightbulb<3,>=2.0.3
+git+https://github.com/tandemdude/hikari-lightbulb@development
 psutil<6,>=5.8
 pygithub<2,>=1.55
 pygount<2,>=1.2


### PR DESCRIPTION
#### Summary

This pull request adds future annotations in places where it can be used in the current code base.
It also restructures the imports from lightbulb.

#### Note
The lightbulb dependency has been updated to the github development branch, for the typing changes in tandemdude/hikari-lightbulb#176, until it is released to pypi.