### PR TITLE
Pin lightbulb to 85be5f due to bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiosqlite~=0.17
 apscheduler<4,>=3.8
 feedparser<7,>=6.0
 hikari[speedups]==2.0.0.dev104
-git+https://github.com/tandemdude/hikari-lightbulb@development
+git+https://github.com/tandemdude/hikari-lightbulb@85be5f576f5c7ec5863f54320b0d7a5fe0b2de2f
 psutil<6,>=5.8
 pygithub<2,>=1.55
 pygount<2,>=1.2


### PR DESCRIPTION
This pull request pins lightbulb to the latest working commit.