### PR TITLE
Implement the binify command in V2

### DIFF
--- a/carberretta/extensions/text.py
+++ b/carberretta/extensions/text.py
@@ -95,10 +95,9 @@ async def cmd_binify(ctx: lightbulb.SlashContext) -> None:
     snowflake: int = ctx.options.snowflake
 
     try:
-        message: hikari.Message = (
-            ctx.bot.cache.get_message(snowflake)
-            or await ctx.bot.rest.fetch_message(ctx.channel_id, snowflake)
-        )
+        message: hikari.Message = ctx.bot.cache.get_message(
+            snowflake
+        ) or await ctx.bot.rest.fetch_message(ctx.channel_id, snowflake)
     except hikari.NotFoundError:
         await ctx.respond(
             f"Could not find message in this channel with ID: {snowflake}"
@@ -112,12 +111,15 @@ async def cmd_binify(ctx: lightbulb.SlashContext) -> None:
         file_contents = ""
 
     if message.content:
-        content = await string.binify(
-            ctx.bot.d.session,
-            message.content,
-            only_codeblocks=True,
-            expires_in_days=expires,
-        ) + "\n\n"
+        content = (
+            await string.binify(
+                ctx.bot.d.session,
+                message.content,
+                only_codeblocks=True,
+                expires_in_days=expires,
+            )
+            + "\n\n"
+        )
     else:
         content = ""
 

--- a/carberretta/extensions/text.py
+++ b/carberretta/extensions/text.py
@@ -95,9 +95,11 @@ async def cmd_binify(ctx: lightbulb.SlashContext) -> None:
     snowflake: hikari.Snowflake = ctx.options.snowflake
 
     try:
-        message: hikari.Message = ctx.bot.cache.get_message(
-            snowflake
-        ) or await ctx.bot.rest.fetch_message(ctx.channel_id, snowflake)
+        message: hikari.Message = (
+            # This comment prevents black from reformatting :)
+            ctx.bot.cache.get_message(snowflake)
+            or await ctx.bot.rest.fetch_message(ctx.channel_id, snowflake)
+        )
     except hikari.NotFoundError:
         await ctx.respond(
             f"Could not find message in this channel with ID: {snowflake}"

--- a/carberretta/extensions/text.py
+++ b/carberretta/extensions/text.py
@@ -93,10 +93,17 @@ async def cmd_charinfo(ctx: lightbulb.SlashContext) -> None:
 async def cmd_binify(ctx: lightbulb.SlashContext) -> None:
     expires: int = ctx.options.expires
     snowflake: int = ctx.options.snowflake
-    message: hikari.Message = (
-        ctx.bot.cache.get_message(snowflake)
-        or await ctx.bot.rest.fetch_message(ctx.channel_id, snowflake)
-    )
+
+    try:
+        message: hikari.Message = (
+            ctx.bot.cache.get_message(snowflake)
+            or await ctx.bot.rest.fetch_message(ctx.channel_id, snowflake)
+        )
+    except hikari.NotFoundError:
+        await ctx.respond(
+            f"Could not find message in this channel with ID: {snowflake}"
+        )
+        return
 
     if message.attachments:
         data = io.BytesIO(await message.attachments[0].read())

--- a/carberretta/extensions/text.py
+++ b/carberretta/extensions/text.py
@@ -79,7 +79,7 @@ async def cmd_charinfo(ctx: lightbulb.SlashContext) -> None:
 @plugin.command
 @lightbulb.option(
     "expires",
-    "The number of days before the bin will expire.",
+    "The number of days before the paste expires.",
     type=int,
     max_value=180,
     min_value=1,
@@ -92,7 +92,7 @@ async def cmd_charinfo(ctx: lightbulb.SlashContext) -> None:
 @lightbulb.implements(lightbulb.SlashCommand)
 async def cmd_binify(ctx: lightbulb.SlashContext) -> None:
     expires: int = ctx.options.expires
-    snowflake: int = ctx.options.snowflake
+    snowflake: hikari.Snowflake = ctx.options.snowflake
 
     try:
         message: hikari.Message = ctx.bot.cache.get_message(

--- a/carberretta/utils/string.py
+++ b/carberretta/utils/string.py
@@ -65,7 +65,7 @@ async def binify(
     *,
     only_codeblocks: bool = False,
     expires_in_days: int = 7,
-    file_extension: str = ""
+    file_extension: str = "",
 ) -> str:
     async def convert(body: str, to_replace: str, ext: str) -> str:
         payload = {

--- a/carberretta/utils/string.py
+++ b/carberretta/utils/string.py
@@ -28,14 +28,14 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import re
 import typing as t
-from datetime import datetime, timedelta
 
 from aiohttp import ClientSession
 
 if t.TYPE_CHECKING:
-    from hikari import Member, User
+    from hikari import User
 
 ORDINAL_ENDINGS: t.Final = {"1": "st", "2": "nd", "3": "rd"}
 
@@ -54,7 +54,7 @@ def ordinal(number: int) -> str:
     return f"{number:,}th"
 
 
-def possessive(user: Member | User) -> str:
+def possessive(user: User) -> str:
     name = getattr(user, "display_name", user.username)
     return f"{name}'{'s' if not name.endswith('s') else ''}"
 
@@ -70,14 +70,14 @@ async def binify(
     async def convert(body: str, to_replace: str, ext: str) -> str:
         payload = {
             "files": [{"filename": f"support{ext}", "content": body}],
-            "expires": str(datetime.now() + timedelta(expires_in_days)),
+            "expires": str(dt.datetime.now() + dt.timedelta(expires_in_days)),
         }
 
-        async with session.put("https://api.mystb.in/paste", json=payload) as response:
-            if not response.ok:
-                return f"Failed calling Mystbin. HTTP status code: {response.status}"
+        async with session.put("https://api.mystb.in/paste", json=payload) as resp:
+            if not resp.ok:
+                return f"Failed calling Mystbin. HTTP status code: {resp.status}"
 
-            data = await response.json()
+            data = await resp.json()
             return text.replace(to_replace, f"<https://mystb.in/{data['id']}>")
 
     if not only_codeblocks:

--- a/carberretta/utils/string.py
+++ b/carberretta/utils/string.py
@@ -74,7 +74,7 @@ async def binify(
         }
 
         async with session.put("https://api.mystb.in/paste", json=payload) as response:
-            if not 200 <= response.status <= 299:
+            if not response.ok:
                 return f"Failed calling Mystbin. HTTP status code: {response.status}"
 
             data = await response.json()


### PR DESCRIPTION
This PR ports V1 `binify` command into V2 as a slash command.

This implementation accepts 2 arguments, the message snowflake and a number of days for when to expire the pastebin if there is one. The expires can be anything from 1-120 days.

Right now if a message isn't cached it will try to fetch, but only in the current channel.
I'm wondering if you can think of any better way to do that, like adding another option channel param maybe?

