### PR TITLE
Port YouTube cog

### DIFF
--- a/carberretta/bot.py
+++ b/carberretta/bot.py
@@ -65,12 +65,8 @@ bot.load_extensions_from("./carberretta/extensions")
 
 @bot.listen(hikari.StartingEvent)
 async def on_starting(_: hikari.StartingEvent) -> None:
-    cookie_jar = CookieJar(loop=asyncio.get_running_loop())
-    cookie_jar.update_cookies(SimpleCookie("CONSENT=YES+cb; Domain=.youtube.com"))
-    log.info("YouTube cookies set")
-
     bot.d.scheduler.start()
-    bot.d.session = ClientSession(trust_env=True, cookie_jar=cookie_jar)
+    bot.d.session = ClientSession(trust_env=True)
     log.info("AIOHTTP session started")
 
     bot.d.db = Database(bot.d._dynamic, bot.d._static)

--- a/carberretta/bot.py
+++ b/carberretta/bot.py
@@ -26,16 +26,14 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import asyncio
 import logging
 import os
 import traceback
-from http.cookies import SimpleCookie
 from pathlib import Path
 
 import hikari
 import lightbulb
-from aiohttp import ClientSession, CookieJar
+from aiohttp import ClientSession
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from hikari.events.base_events import EventT

--- a/carberretta/bot.py
+++ b/carberretta/bot.py
@@ -26,14 +26,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import asyncio
 import logging
 import os
 import traceback
+from http.cookies import SimpleCookie
 from pathlib import Path
 
 import hikari
 import lightbulb
-from aiohttp import ClientSession
+from aiohttp import ClientSession, CookieJar
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from hikari.events.base_events import EventT
@@ -63,8 +65,12 @@ bot.load_extensions_from("./carberretta/extensions")
 
 @bot.listen(hikari.StartingEvent)
 async def on_starting(_: hikari.StartingEvent) -> None:
+    cookie_jar = CookieJar(loop=asyncio.get_running_loop())
+    cookie_jar.update_cookies(SimpleCookie("CONSENT=YES+cb; Domain=.youtube.com"))
+    log.info("YouTube cookies set")
+
     bot.d.scheduler.start()
-    bot.d.session = ClientSession(trust_env=True)
+    bot.d.session = ClientSession(trust_env=True, cookie_jar=cookie_jar)
     log.info("AIOHTTP session started")
 
     bot.d.db = Database(bot.d._dynamic, bot.d._static)

--- a/carberretta/extensions/youtube.py
+++ b/carberretta/extensions/youtube.py
@@ -263,9 +263,7 @@ async def cmd_youtube_channel(ctx: lightbulb.SlashContext) -> None:
         .set_footer(f"Requested by {member.display_name}", icon=member.avatar_url)
         .set_thumbnail(data["snippet"]["thumbnails"]["high"]["url"])
         .set_image(data["brandingSettings"]["image"]["bannerExternalUrl"])
-        .add_field(
-            "Subscribers", f"~{int(stats['subscriberCount']):,}", inline=True
-        )
+        .add_field("Subscribers", f"~{int(stats['subscriberCount']):,}", inline=True)
         .add_field("Views", f"{int(stats['viewCount']):,}", inline=True)
         .add_field("Videos", f"{int(stats['videoCount']):,}", inline=True)
         .add_field("Latest video", f"[{latest_title}]({WATCH_URL + latest_id})")

--- a/carberretta/extensions/youtube.py
+++ b/carberretta/extensions/youtube.py
@@ -66,12 +66,12 @@ def _similarity(s1: str, s2: str, **_: t.Any) -> float:
     return max_combo / chars
 
 
-def _video_options(value: str) -> list[str]:
+def _compile_options(value: str, directory: dict[str, str]) -> list[str]:
     return [
         res[0]
         for res in rf.process.extract(
             value,
-            plugin.d.video_directory.keys(),
+            directory.keys(),
             scorer=_similarity,
             limit=10,
             score_cutoff=0.5,
@@ -134,7 +134,7 @@ async def cmd_youtube_video_link_autocomplete(
     opt: hikari.AutocompleteInteractionOption, _: hikari.AutocompleteInteraction
 ) -> list[str]:
     assert isinstance(opt.value, str)
-    return _video_options(opt.value)
+    return _compile_options(opt.value, plugin.d.video_directory)
 
 
 def load(bot: lightbulb.BotApp) -> None:

--- a/carberretta/extensions/youtube.py
+++ b/carberretta/extensions/youtube.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2020-present, Carberra
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+
+import logging
+import typing as t
+
+import hikari
+import lightbulb
+import rapidfuzz as rf
+import scrapetube
+
+from carberretta import Config
+
+plugin = lightbulb.Plugin("YouTube", include_datastore=True)
+log = logging.getLogger(__name__)
+
+
+def _link_options(value: str) -> list[str]:
+    extracted = rf.process.extract(
+        value, plugin.d.directory.keys(), scorer=rf.fuzz.QRatio, limit=15
+    )
+    pure = []
+    partial = []
+
+    for result, _, _ in extracted:
+        if value in result:
+            pure.append(result)
+        else:
+            partial.append(result)
+
+    return pure + partial
+
+
+@plugin.listener(hikari.StartedEvent)
+async def on_started(_: hikari.StartedEvent) -> None:
+    # There is no way to get all videos directly from the API without
+    # either (1) going through OAuth, or (2) brute forcing, with an
+    # eventual cap on 500 results. Scraping isn't exactly ideal, but
+    # it only happens once on startup, and it works, so...get meme'd.
+
+    log.info("Searching for videos...")
+    videos = scrapetube.get_channel(Config.YOUTUBE_CHANNEL_ID)
+
+    log.info(f"Creating directory (this could take some time)...")
+    plugin.d.directory = {v["title"]["runs"][0]["text"]: v["videoId"] for v in videos}
+    log.info(f"Created directory of {len(plugin.d.directory)} videos")
+
+
+@plugin.command
+@lightbulb.command("youtube", "YouTube commands.")
+@lightbulb.implements(lightbulb.SlashCommandGroup)
+async def cmd_youtube(_: lightbulb.SlashContext) -> None:
+    ...
+
+
+@cmd_youtube.child
+@lightbulb.option("title", "The title of the video.", autocomplete=True)
+@lightbulb.command("link", "Link a video (use if directing someone to watch a video).")
+@lightbulb.implements(lightbulb.SlashSubCommand)
+async def cmd_youtube_link(ctx: lightbulb.SlashContext) -> None:
+    video_id = plugin.d.directory[ctx.options.title]
+    await ctx.respond(f"https://youtube.com/watch?v={video_id}")
+
+
+@cmd_youtube_link.autocomplete("title")
+async def cmd_youtube_link_autocomplete(
+    opt: hikari.AutocompleteInteractionOption, _: hikari.AutocompleteInteraction
+) -> list[str]:
+    assert isinstance(opt.value, str)
+    return _link_options(opt.value)
+
+
+def load(bot: lightbulb.BotApp) -> None:
+    bot.add_plugin(plugin)
+
+
+def unload(bot: lightbulb.BotApp) -> None:
+    bot.remove_plugin(plugin)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ isort~=5.10.1
 # Typing
 mypy==0.971
 types-aiofiles~=22.1.0
+types-python-dateutil>=2.8.19,<3
 types-pytz~=2022.2.1
 
 # Line lengths

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ hikari-lightbulb>=2.2.1,<3
 psutil>=5.8,<6
 pygithub>=1.55,<2
 pygount>=1.2,<2
+python-dateutil>=2.8.2,<3
 python-dotenv~=0.21.0
 rapidfuzz>=2.0.7,<3
+scrapetube>=2.3,<3
 uvloop~=0.17.0; os_name != "nt"


### PR DESCRIPTION
This PR ports the YouTube cog into V2.

Currently, the following commands have been implemented:

* `/youtube video link` -- allows users to search for a video using the title (and autocomplete) and return a link
* `/youtube video information` -- allows users to view more detailed information for a video